### PR TITLE
feat: add command to highlight on demand and to toggle the auto highlight

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
   "typescript.tsc.autoDetect": "off",
   "editor.tabSize": 4,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
+    "source.fixAll.eslint": "explicit"
+  },
+  "vimFindHighlight.enableAutoHighlight": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,5 @@
   "editor.tabSize": 4,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
-  },
-  "vimFindHighlight.enableAutoHighlight": false
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,33 +1,30 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": [
-                "$ts-webpack-watch",
-                "$tslint-webpack-watch"
-			],
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		},
-		{
-			"type": "npm",
-			"script": "test-watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": "build"
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": ["$ts-webpack-watch", "$tslint-webpack-watch"],
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "type": "npm",
+      "script": "test-watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": "build"
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@
 
 This extension exposes two commands (accessible through the command palette):
 
-- `Toggle Auto Highlight`: Enables or disables the autohighlight setting described above.
-- `Highlight Characters`: Force a highlight of jumpable characters. Useful when paired with `vimFindHighlight.enableAutoHighlight: false`.
+- `Vim Find Highlight: Toggle Auto Highlight`: Enables or disables the autohighlight setting described above.
+- `Vim Find Highlight: Highlight Characters`: Force a highlight of jumpable characters. Useful when paired with `vimFindHighlight.enableAutoHighlight: false`.
 
 You can remap the `Highlight Characters` command either using VSCode native keyword shortcuts, or [vscode vim](https://github.com/VSCodeVim/Vim) KeyBindings.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@
 
   4. ` "vimFindHighlight.enableUnderline": true // underline the highlighted characters`
 
+  5. `"vimFindHighlight.enableAutoHighlight": true // highlight characters automatically`
+  
+
+## Commands
+
+This extension exposes two commands (accessible through the command palette):
+
+- `Toggle Auto Highlight`: Enables or disables the autohighlight setting described above.
+- `Highlight Characters`: Force a highlight of jumpable characters. Useful when paired with `vimFindHighlight.enableAutoHighlight: false`.
+
+You can remap the `Highlight Characters` command either using VSCode native keyword shortcuts, or [vscode vim](https://github.com/VSCodeVim/Vim) KeyBindings.
+
 ## Links
 
 - [github link](https://github.com/magdyamr542/vim-find-highlight)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10521,19 +10521,22 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -10557,13 +10560,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -10590,7 +10595,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -11203,7 +11209,8 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
       "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -12624,7 +12631,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -14379,7 +14387,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-jest": {
       "version": "29.1.2",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,24 @@
           "type": "boolean",
           "default": true,
           "description": "If true, a line will be drawn under the highlighted characters"
+        },
+        "vimFindHighlight.enableAutoHighlight": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true, the extension will automatically highlight the characters that can be reached with the f motion"
         }
       }
     },
-    "commands": []
+    "commands": [
+      {
+        "command": "vimFindHighlight.toggleAuthoHighlight",
+        "title": "Toggle Auto Highlight"
+      },
+      {
+        "command": "vimFindHighlight.highlightCharacters",
+        "title": "Highlight Characters"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run -S esbuild-base -- --minify",

--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "commands": [
       {
         "command": "vimFindHighlight.toggleAuthoHighlight",
-        "title": "Toggle Auto Highlight"
+        "title": "Vim Find Highlight: Toggle Auto Highlight"
       },
       {
         "command": "vimFindHighlight.highlightCharacters",
-        "title": "Highlight Characters"
+        "title": "Vim Find Highlight: Highlight Characters"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeTextDocument((e) => {
       const line = getCurrentLine();
       const cursorPos = getCursorPos();
-      if (line?.text.length && cursorPos && autoHighlight) {
+      if (line?.text.length && cursorPos != undefined && autoHighlight) {
         main(cursorPos, line.text);
       } else {
         disposeCharDecoration();
@@ -68,7 +68,6 @@ const configureAutoHighlight = (): boolean => {
   const autoHighlight = settings.get(
     "vimFindHighlight.enableAutoHighlight"
   ) as boolean;
-  vscode.window.showInformationMessage(autoHighlight.toString());
   return autoHighlight;
 };
 
@@ -92,7 +91,7 @@ const registerCommands = (context: vscode.ExtensionContext) => {
 const highlightCharacters = () => {
   const line = getCurrentLine();
   const cursorPos = getCursorPos();
-  if (line?.text.length && cursorPos) {
+  if (line?.text.length && cursorPos != undefined) {
     main(cursorPos, line.text);
   } else {
     disposeCharDecoration();
@@ -107,6 +106,18 @@ export function toggleAutoHighlight() {
   const autoHighlight = settings.get(
     "vimFindHighlight.enableAutoHighlight"
   ) as boolean;
-  settings.update("vimFindHighlight.enableAutoHighlight", !autoHighlight);
+  settings
+    .update(
+      "vimFindHighlight.enableAutoHighlight",
+      !autoHighlight,
+      vscode.ConfigurationTarget.Global
+    )
+    .then(
+      () => {},
+      (reason) =>
+        vscode.window.showInformationMessage(
+          "Failed to toggle auto highlight: " + reason
+        )
+    );
   highlightCharacters();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,14 +8,15 @@ import {
 import { colorChars, getCurrentLine, getCursorPos } from "./utils";
 
 export function activate(context: vscode.ExtensionContext) {
+  let autoHighlight = configureAutoHighlight();
 
   // when the user types
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((e) => {
       const line = getCurrentLine();
       const cursorPos = getCursorPos();
-      if (line?.text.length && cursorPos) {
-        main(cursorPos, line.text)
+      if (line?.text.length && cursorPos && autoHighlight) {
+        main(cursorPos, line.text);
       } else {
         disposeCharDecoration();
       }
@@ -27,7 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.onDidChangeTextEditorSelection((e) => {
       const line = getCurrentLine();
       const cursorPos = e.textEditor.selection.active.character;
-      if (line?.text.length) {
+      if (line?.text.length && autoHighlight) {
         main(cursorPos, line.text);
       } else {
         disposeCharDecoration();
@@ -38,16 +39,23 @@ export function activate(context: vscode.ExtensionContext) {
   // listen for configuration changes
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      const configChanged = e.affectsConfiguration('vimFindHighlight.charPrimaryColor') || e.affectsConfiguration('vimFindHighlight.charSecondaryColor') || e.affectsConfiguration('vimFindHighlight.charFontWeight') || e.affectsConfiguration('vimFindHighlight.enableUnderline');
+      const configChanged =
+        e.affectsConfiguration("vimFindHighlight.charPrimaryColor") ||
+        e.affectsConfiguration("vimFindHighlight.charSecondaryColor") ||
+        e.affectsConfiguration("vimFindHighlight.charFontWeight") ||
+        e.affectsConfiguration("vimFindHighlight.enableUnderline") ||
+        e.affectsConfiguration("vimFindHighlight.enableAutoHighlight");
 
       if (configChanged) {
         configureDecoration();
+        autoHighlight = configureAutoHighlight();
       }
     })
-  )
+  );
 
-  // when activating the extension. read the user settings file first
+  // when activating the extension. read the user settings file first and register the commands
   configureDecoration();
+  registerCommands(context);
 }
 
 const configureDecoration = () => {
@@ -55,10 +63,50 @@ const configureDecoration = () => {
   disposeCharDecoration();
 };
 
+const configureAutoHighlight = (): boolean => {
+  const settings = vscode.workspace.getConfiguration();
+  const autoHighlight = settings.get(
+    "vimFindHighlight.enableAutoHighlight"
+  ) as boolean;
+  vscode.window.showInformationMessage(autoHighlight.toString());
+  return autoHighlight;
+};
+
 const main = (cursorPos: number, currentLine: string) => {
   const toColor = charHighlighter.getCharHighlighting(currentLine, cursorPos);
   colorChars(toColor, decorationConfig);
 };
 
+const registerCommands = (context: vscode.ExtensionContext) => {
+  const toggleCommand = "vimFindHighlight.toggleAuthoHighlight";
+  context.subscriptions.push(
+    vscode.commands.registerCommand(toggleCommand, toggleAutoHighlight)
+  );
+
+  const highlightCommand = "vimFindHighlight.highlightCharacters";
+  context.subscriptions.push(
+    vscode.commands.registerCommand(highlightCommand, highlightCharacters)
+  );
+};
+
+const highlightCharacters = () => {
+  const line = getCurrentLine();
+  const cursorPos = getCursorPos();
+  if (line?.text.length && cursorPos) {
+    main(cursorPos, line.text);
+  } else {
+    disposeCharDecoration();
+  }
+};
+
 // this method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {}
+
+export function toggleAutoHighlight() {
+  const settings = vscode.workspace.getConfiguration();
+  const autoHighlight = settings.get(
+    "vimFindHighlight.enableAutoHighlight"
+  ) as boolean;
+  settings.update("vimFindHighlight.enableAutoHighlight", !autoHighlight);
+  highlightCharacters();
+}


### PR DESCRIPTION
Quick and dirty solution that allows one to:
- Toggle the autohighlight feature on demand.
- Configure the autohighlight in settings.json
- Call a command to force a highlight of characters (which can be remapped however the user prefers).

refs #3 